### PR TITLE
Add optional local storage for generated images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ REDIS_URL="redis://localhost:6379/0"
 SENTRY_DSN="http://sntryu_xx0000000000000xx@localhost:9000/1"
 SMS_API_URL='https://api.com.br/send'
 SMS_API_KEY="<API-KEY>"
+AWS_ACCESS_KEY_ID=""
+AWS_REGION="us-east-1"
+S3_BUCKET="bucket-name"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
    $env:AWS_ACCESS_KEY_ID="XXXXXXXXXXXXXX"
    $env:AWS_SECRET_ACCESS_KEY="XXXXXXXXX"
    $env:AWS_REGION="us-east-1"
+   # Se AWS_ACCESS_KEY_ID ficar vazio, as imagens serão salvas localmente
    ```
 
 Depois rode assim para debuggar
@@ -102,6 +103,7 @@ docker run -d \
   -e AWS_REGION="us-east-1"
   comfyui-api
 ```
+Caso `AWS_ACCESS_KEY_ID` esteja vazio, as imagens serão mantidas em disco e o armazenamento S3 não será utilizado.
 
 > **Flags principais**
 >

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     DEFAULT_PROCESSING_TIME: int = Field(8000, env="DEFAULT_PROCESSING_TIME")
     AWS_REGION: str = Field(..., env="AWS_REGION")
     S3_BUCKET: str = Field(..., env="S3_BUCKET")
+    AWS_ACCESS_KEY_ID: Optional[str] = Field(default=None, env="AWS_ACCESS_KEY_ID")
 
 
     class Config:

--- a/src/routes/routes.py
+++ b/src/routes/routes.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 
 from fastapi import APIRouter, Request, UploadFile, File, Form, HTTPException, Query
-from fastapi.responses import JSONResponse, HTMLResponse
+from fastapi.responses import JSONResponse, HTMLResponse, FileResponse
 from fastapi.templating import Jinja2Templates
 from fastapi import BackgroundTasks
 
@@ -17,6 +17,7 @@ from core.config import settings
 from core.redis import redis
 from utils.sms import format_to_e164, send_sms_download_message
 from utils.s3 import upload_fileobj
+from fastapi.responses import FileResponse
 
 
 router = APIRouter()
@@ -43,6 +44,14 @@ async def index():
 @router.get("/alive")
 async def alive():
     return "Alive"
+
+
+@router.get("/image/{path:path}")
+async def serve_image(path: str):
+    file_path = os.path.join(settings.STATIC_DIR, path)
+    if not os.path.isfile(file_path):
+        raise HTTPException(status_code=404, detail="Arquivo não encontrado")
+    return FileResponse(file_path)
 
 @router.post("/api/upload")
 async def upload(

--- a/src/utils/s3.py
+++ b/src/utils/s3.py
@@ -2,54 +2,74 @@ from core.config import settings
 import boto3
 from botocore.client import Config
 import uuid
+import os
 
 # Definimos o endpoint region-specific
-ENDPOINT = f"https://s3.{settings.AWS_REGION}.amazonaws.com"
+USE_S3 = bool(settings.AWS_ACCESS_KEY_ID)
 
-s3_client = boto3.client(
-    "s3",
-    endpoint_url=ENDPOINT,
-    region_name=settings.AWS_REGION,
-    config=Config(signature_version="s3v4")
-)
+if USE_S3:
+    ENDPOINT = f"https://s3.{settings.AWS_REGION}.amazonaws.com"
+    s3_client = boto3.client(
+        "s3",
+        endpoint_url=ENDPOINT,
+        region_name=settings.AWS_REGION,
+        config=Config(signature_version="s3v4"),
+    )
+else:
+    s3_client = None
 
 def public_url(key: str) -> str:
-    return f"https://{settings.S3_BUCKET}.s3.{settings.AWS_REGION}.amazonaws.com/{key}"
+    if USE_S3:
+        return f"https://{settings.S3_BUCKET}.s3.{settings.AWS_REGION}.amazonaws.com/{key}"
+    return f"{settings.BASE_URL}/image/{key}"
 
 
 def upload_fileobj(file_obj, key_prefix: str, extension: str = "png") -> str:
-    """
-    Faz upload de um file-like object para S3, retornando o key gerado com extensão.
-    """
+    """Upload de arquivo para S3 ou armazenamento local."""
     key = f"{key_prefix}/{uuid.uuid4()}.{extension}"
-    s3_client.upload_fileobj(
-        file_obj,
-        settings.S3_BUCKET,
-        key,
-        ExtraArgs={
-            "ContentType": f"image/{extension}"
-        }
-    )
+    if USE_S3:
+        s3_client.upload_fileobj(
+            file_obj,
+            settings.S3_BUCKET,
+            key,
+            ExtraArgs={"ContentType": f"image/{extension}"},
+        )
+    else:
+        dest = os.path.join(settings.STATIC_DIR, key)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        file_obj.seek(0)
+        with open(dest, "wb") as f:
+            f.write(file_obj.read())
     return key
 
 
 def create_presigned_upload(key_prefix: str, content_type: str, expires_in: int = 3600):
     key = f"{key_prefix}/{uuid.uuid4()}"
-    url = s3_client.generate_presigned_url(
-        ClientMethod="put_object",
-        Params={
-            "Bucket": settings.S3_BUCKET,
-            "Key": key,
-            "ContentType": content_type,
-        },
-        ExpiresIn=expires_in,
-    )
-    return {"url": url, "key": key}
+    if USE_S3:
+        url = s3_client.generate_presigned_url(
+            ClientMethod="put_object",
+            Params={"Bucket": settings.S3_BUCKET, "Key": key, "ContentType": content_type},
+            ExpiresIn=expires_in,
+        )
+        return {"url": url, "key": key}
+    else:
+        return {"url": None, "key": key}
 
 
 def create_presigned_download(key: str, expires_in: int = 3600) -> str:
-    return s3_client.generate_presigned_url(
-        ClientMethod="get_object",
-        Params={"Bucket": settings.S3_BUCKET, "Key": key},
-        ExpiresIn=expires_in,
-    )
+    if USE_S3:
+        return s3_client.generate_presigned_url(
+            ClientMethod="get_object",
+            Params={"Bucket": settings.S3_BUCKET, "Key": key},
+            ExpiresIn=expires_in,
+        )
+    return f"{settings.BASE_URL}/image/{key}"
+
+def download_file(key: str) -> bytes:
+    """Baixa arquivo do S3 ou do armazenamento local."""
+    if USE_S3:
+        obj = s3_client.get_object(Bucket=settings.S3_BUCKET, Key=key)
+        return obj["Body"].read()
+    path = os.path.join(settings.STATIC_DIR, key)
+    with open(path, "rb") as f:
+        return f.read()


### PR DESCRIPTION
## Summary
- make AWS credentials optional
- if `AWS_ACCESS_KEY_ID` is empty, store files locally
- expose `/image/{path}` to serve local files
- document new behaviour in README and `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862dd62350c832da2a269e31a51a1db